### PR TITLE
dev/drop python36

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fix
+- Drop Python 3.6 support, #58.
+
 ## [0.10.0] - 2022-01-06
 ### Fix
 - Internal type annotations to be compatible with streamlit>=1.3, #581.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/whitphx/streamlit-server-state"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 streamlit = ">=0.65.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
- Remove Python 3.6 from the dependency defined in pyproject.toml
- Remove Python 3.6 and add 3.9 from/to the CI version matrix
