### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         streamlit-version: [null]
         include:
           # Test with streamlit <1.4.0 and >=1.4.0. See https://github.com/whitphx/streamlit-server-state/issues/64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/whitphx/streamlit-server-state"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4,!=3.9.7"  # 3.9.7 is excluded due to https://github.com/streamlit/streamlit/pull/5168
+python = ">=3.8,<4,!=3.9.7"  # 3.9.7 is excluded due to https://github.com/streamlit/streamlit/pull/5168
 streamlit = ">=0.65.0"
 packaging = ">=20.0"
 


### PR DESCRIPTION
It already reached its EOL: https://devguide.python.org/versions/