### PR TITLE
NoSessionRerun and Fragment reruns

### DIFF
--- a/streamlit_server_state/rerun_session_suppression.py
+++ b/streamlit_server_state/rerun_session_suppression.py
@@ -1,0 +1,48 @@
+import logging
+
+from .app_context import get_app_context
+from .session_info import NoSessionError, get_this_session
+
+logger = logging.getLogger(__name__)
+
+_SERVER_STATE_SESSION_RERUN_SUPPRESSION_ATTR_NAME_ = "__SERVER_STATE_SUPPRESS_SESSION_RERUN__"
+
+
+class NoSessionRerunSuppressor:
+    def __enter__(self) -> None:
+        logger.debug("Start suppressing setting session rerunning")
+
+        # Context managers used in Streamlit apps should be managed
+        # being bound to the app context object
+        # following the design of the built-in components
+        # that are used in `with` statements.
+        # Ref: https://github.com/streamlit/streamlit/blob/1.15.0/lib/streamlit/delta_generator.py#L282-L300 # noqa: E501
+        this_session = get_this_session()
+        ctx = get_app_context(this_session)
+
+        setattr(ctx, _SERVER_STATE_SESSION_RERUN_SUPPRESSION_ATTR_NAME_, True)
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        this_session = get_this_session()
+        ctx = get_app_context(this_session)
+
+        delattr(ctx, _SERVER_STATE_SESSION_RERUN_SUPPRESSION_ATTR_NAME_)
+
+        logger.debug("Finished suppressing rerunning for setting session")
+
+
+no_session_rerun = NoSessionRerunSuppressor()
+
+
+def is_session_rerun_suppressed() -> bool:
+    try:
+        this_session = get_this_session()
+    except NoSessionError:
+        return False
+
+    ctx = get_app_context(this_session)
+
+    session_rerun_suppressed = getattr(ctx, _SERVER_STATE_SESSION_RERUN_SUPPRESSION_ATTR_NAME_, False)
+    logger.debug("Check the session-rerun-suppression flag: %r", session_rerun_suppressed)
+
+    return session_rerun_suppressed

--- a/streamlit_server_state/server_state_item.py
+++ b/streamlit_server_state/server_state_item.py
@@ -2,9 +2,12 @@ import threading
 import weakref
 from typing import Generic, Optional, TypeVar
 
+from streamlit.proto.ClientState_pb2 import ClientState
+
 from .app_context import AppSession, is_rerunnable
 from .hash import Hash, calc_hash
 from .rerun_suppression import is_rerun_suppressed
+from .rerun_session_suppression import is_session_rerun_suppressed
 
 StateValueT = TypeVar("StateValueT")
 
@@ -35,29 +38,39 @@ class ServerStateItem(Generic[StateValueT]):
             if session not in self._bound_sessions:
                 self._bound_sessions.add(session)
 
-    def _rerun_bound_sessions(self) -> None:
+    def _rerun_bound_sessions(self, setting_session = None, refresh_fragments = None) -> None:
         with self._bound_sessions_lock:
             for session in self._bound_sessions:
-                self._rerun_session_if_possible(session)
+                if session is setting_session and is_session_rerun_suppressed():
+                    continue
+                else:
+                    if refresh_fragments and session.id in refresh_fragments:
+                        session_fragment_id = refresh_fragments[session.id]
+                    else:
+                        session_fragment_id = None
+                    self._rerun_session_if_possible(session, fragment_id=session_fragment_id)
 
-    def _rerun_session_if_possible(self, session: AppSession) -> None:
+    def _rerun_session_if_possible(self, session: AppSession, fragment_id: str = None) -> None:
         if is_rerunnable(session):
-            session.request_rerun(client_state=None)  # HACK: XD
+            if fragment_id is None:
+                session.request_rerun(client_state=None)
+            else:
+                session.request_rerun(client_state=ClientState(fragment_id=fragment_id, is_auto_rerun=False))
 
-    def _on_set(self):
+    def _on_set(self, setting_session: Optional[AppSession], refresh_fragments = None) -> None:
         new_value_hash = calc_hash(self._value)
         if not is_rerun_suppressed():
             if self._value_hash is None or self._value_hash != new_value_hash:
-                self._rerun_bound_sessions()
+                self._rerun_bound_sessions(setting_session, refresh_fragments)
 
         self._value_hash = new_value_hash
 
-    def set_value(self, value: StateValueT) -> None:
+    def set_value(self, value: StateValueT, setting_session = None, refresh_fragments = None) -> None:
         with self._value_lock:
             self._is_set = True
             self._value = value
 
-        self._on_set()
+        self._on_set(setting_session, refresh_fragments)
 
     def get_value(self) -> StateValueT:
         with self._value_lock:


### PR DESCRIPTION
Adds NoSessionRerun, so you can do:

with no_session_rerun:
    server_state['foo'] = bar

This will cause all sessions bound to 'foo' to be rerun *except* the session setting the value. 
The idea is that the session that sets the value already knows the value and does not require a rerun.
This is also helpful to prevent circular updates.

Adds fragment reruns, so you can have specific fragments rerun when a certain key in the server_state is mutated.
Like:

```python

@st.fragment
def messages_fragment():
    server_state.register_current_fragment_rerun(for_updates_to='messages')
    st.write(st.session_state.messages)

...

server_state['messages'] = server_state['messages'] + [message]

```

When the 'messages' array is updated it does not do a complete app rerun, but instead only reruns a specific fragment (in all sessions).
