### PR TITLE
ci: Add Aikido Safe Chain to test and build jobs

### DIFF
--- a/.github/actions/install-safe-chain/action.yml
+++ b/.github/actions/install-safe-chain/action.yml
@@ -6,6 +6,19 @@ description: >-
 runs:
   using: composite
   steps:
-    - name: Install Aikido Safe Chain
+    - name: Download and verify Aikido Safe Chain installer
       shell: bash
-      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      env:
+        # Pin to a specific release. Bump the version and checksum together.
+        # Checksum comes from the GitHub release asset digest:
+        #   gh release view --repo AikidoSec/safe-chain 1.4.7 --json assets
+        SAFE_CHAIN_VERSION: "1.4.7"
+        SAFE_CHAIN_INSTALLER_SHA256: "54c750232d149106ecf4f5f28fee82ba49d2428f1e411e0ed961c0263ae19eaf"
+      run: |
+        set -euo pipefail
+        installer="$(mktemp)"
+        url="https://github.com/AikidoSec/safe-chain/releases/download/${SAFE_CHAIN_VERSION}/install-safe-chain.sh"
+        curl -fL -o "$installer" "$url"
+        echo "${SAFE_CHAIN_INSTALLER_SHA256}  ${installer}" | sha256sum -c -
+        sh "$installer" --ci
+        rm -f "$installer"

--- a/.github/actions/install-safe-chain/action.yml
+++ b/.github/actions/install-safe-chain/action.yml
@@ -1,0 +1,11 @@
+name: Install Aikido Safe Chain
+description: >-
+  Install Aikido Safe Chain in CI mode so that subsequent npm/yarn/pnpm
+  invocations are scanned for malicious packages before execution.
+  See https://github.com/AikidoSec/safe-chain#usage-in-cicd
+runs:
+  using: composite
+  steps:
+    - name: Install Aikido Safe Chain
+      shell: bash
+      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,9 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Install Aikido Safe Chain
+      uses: ./.github/actions/install-safe-chain
+
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2
 
@@ -93,6 +96,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0  # Fetch all history for hatch-vcs to get the correct version
+
+      - name: Install Aikido Safe Chain
+        uses: ./.github/actions/install-safe-chain
 
       - name: Install uv
         uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2


### PR DESCRIPTION
Install Aikido Safe Chain in CI mode before any package-manager invocation so subsequent npm/yarn/pnpm commands are scanned for malicious packages. Extracted into a reusable composite action at .github/actions/install-safe-chain.

See https://github.com/AikidoSec/safe-chain#usage-in-cicd